### PR TITLE
numalign: support multiple devices from same resource pool

### DIFF
--- a/internal/pkg/numalign/numalign.go
+++ b/internal/pkg/numalign/numalign.go
@@ -188,7 +188,9 @@ func GetPCIDevicesFromEnv(environ []string) []string {
 			continue
 		}
 		pair := strings.SplitN(envVar, "=", 2)
-		pciDevs = append(pciDevs, pair[1])
+		for _, pciDev := range strings.Split(pair[1], ",") {
+			pciDevs = append(pciDevs, pciDev)
+		}
 	}
 	return pciDevs
 }


### PR DESCRIPTION
Add support for multiple devices from the same extended resource pool,
which would be exported in an environment variable like:

```
PCIDEVICE_INTEL_COM_SRIOV=0000:03:02.1,0000:03:04.3
```

https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin#pod-device-information

Signed-off-by: Phil Sphicas <philsphicas@microsoft.com>
